### PR TITLE
refactor(core): migrate Google AI SDK usage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,6 @@
         "@faker-js/faker": "^9.8.0",
         "@google-cloud/vertexai": "^1.7.0",
         "@google/genai": "^1.10.0",
-        "@google/generative-ai": "^0.14.1",
         "@huggingface/inference": "^2.8.0",
         "@modelcontextprotocol/sdk": "^1.17.4",
         "@pinecone-database/pinecone": "^3.0.0",

--- a/packages/core/src/types/LLM.types.ts
+++ b/packages/core/src/types/LLM.types.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
 import Anthropic from '@anthropic-ai/sdk';
-import { FunctionCallingMode, ModelParams, GenerateContentRequest } from '@google/generative-ai';
+import { FunctionCallingConfigMode } from '@google/genai';
 
 import { BinaryInput } from '@sre/helpers/BinaryInput.helper';
 import { type models } from '@sre/LLMManager/models';
@@ -358,7 +358,7 @@ export interface LegacyToolDefinition extends ToolDefinition {
     properties?: Record<string, unknown>;
     requiredFields?: string[];
 }
-export type ToolChoice = OpenAI.ChatCompletionToolChoiceOption | FunctionCallingMode;
+export type ToolChoice = OpenAI.ChatCompletionToolChoiceOption | FunctionCallingConfigMode;
 
 export interface ToolsConfig {
     tools?: ToolDefinition[];
@@ -514,6 +514,33 @@ export type TOpenAIRequestBody =
 
 export type TAnthropicRequestBody = Anthropic.MessageCreateParamsNonStreaming;
 
-export type TGoogleAIRequestBody = ModelParams & { messages: string | TLLMMessageBlock[] | GenerateContentRequest };
+export type TGoogleAIToolPrompt = {
+    contents: any;
+    systemInstruction?: any;
+    tools?: any;
+    toolConfig?: {
+        functionCallingConfig?: {
+            mode?: FunctionCallingConfigMode;
+            allowedFunctionNames?: string[];
+        };
+    };
+};
+
+export interface TGoogleAIRequestBody {
+    model: string;
+    messages?: string | TLLMMessageBlock[] | TGoogleAIToolPrompt;
+    contents?: any;
+    systemInstruction?: any;
+    generationConfig?: {
+        maxOutputTokens?: number;
+        temperature?: number;
+        topP?: number;
+        topK?: number;
+        stopSequences?: string[];
+        responseMimeType?: string;
+    };
+    tools?: any;
+    toolConfig?: any;
+}
 
 export type TLLMRequestBody = TOpenAIRequestBody | TAnthropicRequestBody | TGoogleAIRequestBody | ConverseCommandInput;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
       '@google/genai':
         specifier: ^1.10.0
         version: 1.10.0(@modelcontextprotocol/sdk@1.17.4)(bufferutil@4.0.9)(encoding@0.1.13)
-      '@google/generative-ai':
-        specifier: ^0.14.1
-        version: 0.14.1
       '@huggingface/inference':
         specifier: ^2.8.0
         version: 2.8.1
@@ -1001,10 +998,6 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
-
-  '@google/generative-ai@0.14.1':
-    resolution: {integrity: sha512-pevEyZCb0Oc+dYNlSberW8oZBm4ofeTD5wN01TowQMhTwdAbGAnJMtQzoklh6Blq2AKsx8Ox6FWa44KioZLZiA==}
-    engines: {node: '>=18.0.0'}
 
   '@grpc/grpc-js@1.7.3':
     resolution: {integrity: sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==}
@@ -6606,8 +6599,6 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
-
-  '@google/generative-ai@0.14.1': {}
 
   '@grpc/grpc-js@1.7.3':
     dependencies:


### PR DESCRIPTION
## Summary
- migrate the GoogleAI connector to use the @google/genai client for request, streaming, and file workflows
- expand shared Google AI types to reflect the new prompt and tool configuration shape
- drop the deprecated @google/generative-ai dependency from the core package

## Testing
- pnpm --filter @smythos/sre build

------
https://chatgpt.com/codex/tasks/task_b_68d017cc0838832194fe73a44a56d3fe